### PR TITLE
historical_consumption: fix upper interval

### DIFF
--- a/ideenergy/client.py
+++ b/ideenergy/client.py
@@ -345,7 +345,7 @@ class Client:
         data = await self.request_json("GET", url, encoding="iso-8859-1")
 
         ret = parsers.parse_historical_consumption(data)
-        ret.periods = [x for x in ret.periods if x.start >= start and x.end < end]
+        ret.periods = [x for x in ret.periods if x.start >= start and x.end <= end]
 
         LOGGER.debug(f"{self}: historical consumption fetched succesfully")
 


### PR DESCRIPTION
When fetching historical data, the final period of the last day is currently filtered out.
This final period is from 23:00 of the last considered day until 00:00 of the next day (which is the day that was specified as the "end" argument).

The attached patch fixes that.