### PR TITLE
add cli arguments for start and end dates

### DIFF
--- a/ideenergy/cli.py
+++ b/ideenergy/cli.py
@@ -51,6 +51,9 @@ def build_arg_parser():
     parser.add_argument("--get-historical-generation", action="store_true")
     parser.add_argument("--get-historical-power-demand", action="store_true")
 
+    parser.add_argument("--start", type=datetime.fromisoformat)
+    parser.add_argument("--end", type=datetime.fromisoformat)
+
     return parser
 
 
@@ -67,8 +70,17 @@ async def amain():
         if args.get_measure:
             return await client.get_measure()
 
-        end = datetime.now().replace(hour=0, minute=0, second=0)
-        start = end - timedelta(days=7)
+        now_day = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        seven_days = timedelta(days=7)
+        start = args.start
+        end = args.end
+        if not end:
+            if start:
+                end = min(now_day, start + seven_days)
+            else:
+                end = now_day
+        if not start:
+            start = end - seven_days
 
         if args.get_historical_consumption:
             return await client.get_historical_consumption(start, end)


### PR DESCRIPTION
This PR adds cli arguments to specify the start and end dates for get_historical_consumption() and get_historical_generation().