### PR TITLE
Add missing @auth_required to get_historical_generation

### DIFF
--- a/ideenergy/client.py
+++ b/ideenergy/client.py
@@ -360,6 +360,7 @@ class Client:
         ret = parsers.parse_in_progress_consumption(data)
         return ret
 
+    @auth_required
     async def get_historical_generation(
         self, start: datetime, end: datetime
     ) -> HistoricalGeneration:


### PR DESCRIPTION
## Summary
- `get_historical_generation()` is missing the `@auth_required` decorator that all other authenticated API methods have
- This causes 403 errors when the session expires (after the configurable timeout, default 300s)
- In long-lived clients like the Home Assistant integration, the session expires between polling intervals, and generation data requests fail because they don't trigger automatic re-authentication

## Fix
Added `@auth_required` decorator to `get_historical_generation()`, matching the pattern of `get_historical_consumption()`, `get_historical_power_demand()`, and all other methods that require authentication.

## Error observed in Home Assistant
```
GET URL 'https://www.i-de.es/consumidores/rest/consumoNew/obtenerDatosGeneracionPeriodo/fechaInicio/26-03-202600:00:00/fechaFinal/02-04-202600:00:00/' failed (status=403)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)