### PR TITLE
Fix missing @auth_required and __str__ f-string bug

### DIFF
--- a/ideenergy/client.py
+++ b/ideenergy/client.py
@@ -136,7 +136,7 @@ class Client:
         self._login_ts: datetime | None = None
 
     def __str__(self) -> str:
-        return f"{self.username}" + ("/{self.contract}" if self.contract else "")
+        return f"{self.username}" + (f"/{self.contract}" if self.contract else "")
 
     def __repr__(self) -> str:
         return (

--- a/ideenergy/client.py
+++ b/ideenergy/client.py
@@ -360,6 +360,7 @@ class Client:
         ret = parsers.parse_in_progress_consumption(data)
         return ret
 
+    @auth_required
     async def get_historical_generation(
         self, start: datetime, end: datetime
     ) -> HistoricalGeneration:


### PR DESCRIPTION
## Summary

Two fixes for the `ideenergy` client library.

### Missing `@auth_required` on `get_historical_generation`
- `get_historical_generation()` was missing the `@auth_required` decorator that all other authenticated API methods have
- This causes 403 errors in long-lived clients (like the HA integration) when the session expires, because the method doesn't trigger automatic re-login
- All other methods (`get_historical_consumption`, `get_historical_power_demand`, `get_measure`, etc.) already have this decorator

### `__str__` f-string bug
- `Client.__str__` used `("/{self.contract}" if ...)` instead of `(f"/{self.contract}" if ...)`
- Log messages showed the literal text `{self.contract}` instead of the actual contract value

## Test plan
- [ ] `get_historical_generation` auto-re-authenticates when session expires
- [ ] Log messages show actual contract value instead of `{self.contract}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)